### PR TITLE
Log string instead of byte slice for wrong command

### DIFF
--- a/server/dispatch.go
+++ b/server/dispatch.go
@@ -56,7 +56,7 @@ func (d *Dispatcher) Dispatch(c *Connection, verb []byte) bool {
 		if _, err := c.r.DecodeCompat(); err != nil {
 			return false
 		}
-		fmt.Println("unsupported command:", verb)
+		fmt.Println("unsupported command:", string(verb))
 		c.Write(respNotImplemented)
 		return true
 	}


### PR DESCRIPTION
As of now, server uses byte slice([]byte) to print out error messages caused by wrong client commands (not yet implemented - resulting in 501 response code).

This causes a little inconvenience in debugging, so I have changed the format to string representation of that byte slice.

Waiting for your comments on this, @huguesb.
